### PR TITLE
ROpenSci review feedback, round 2

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,10 +13,9 @@ data-raw
 paper.bib
 paper.md
 paper.pdf
-rnassqs.Rcheck 
-rnassqs_*.tar.gz
+rnassqs.Rcheck
+rnassqs_.*.tar.gz
 CONDUCT.md
 CONTRIBUTING.md
 ^profile.xcf$
 ^profile.png$
-

--- a/R/request.R
+++ b/R/request.R
@@ -216,8 +216,8 @@ nassqs_parse <- function(req, as = c("data.frame", "list", "text"), ...) {
   # process the data depending on returned data type
   if(as == "text") {
     ret <- resp
-  }
-  else if(type %in% c("application/json", "application/json; charset=UTF-8")) { # format == JSON
+  } else if(type %in% c("application/json", "application/json; charset=UTF-8")) {
+    # format == JSON
     # Handle error where response is truncated if too long (only happens)
     # when making a call to the "get_param_values" api_path for 'domaincat_desc'
     ret <- tryCatch(jsonlite::fromJSON(resp),
@@ -228,12 +228,12 @@ nassqs_parse <- function(req, as = c("data.frame", "list", "text"), ...) {
                                   e)) })
     if("data" %in% names(ret)) ret <- ret$data
 
-  }
-  else if(type %in% c("application/xml", "application/xml; charset=UTF-8")) { # format == XML
+  } else if(type %in% c("application/xml", "application/xml; charset=UTF-8")) {
+    # format == XML
     stop(paste0("XML not yet implemented. Use format = 'JSON' or format = ",
                 "'CSV' instead."))
-  }
-  else if(type %in% c("text/csv", "text/csv; charset=UTF-8")) { # format == CSV
+  } else if(type %in% c("text/csv", "text/csv; charset=UTF-8")) {
+    # format == CSV
     ret <- read.csv(text = resp, sep =",", header = TRUE, ...)
     names(ret)[which(names(ret) == "CV....")] <- "CV (%)"
   } else {

--- a/R/request.R
+++ b/R/request.R
@@ -1,16 +1,16 @@
 #' Get data and return a data frame
 #'
 #' The primary function in the `rnassqs` package, `nassqs` makes a HTTP GET
-#' request to the USDA-NASS Quick Stats API and returns the data parsed as a 
+#' request to the USDA-NASS Quick Stats API and returns the data parsed as a
 #' data.frame, plain text, or list. Various other functions make use of `nassqs`
-#' to make specific queries. For a data request the Quick Stats API returns 
-#' JSON that when parsed to a data.frame contains 39 columns and a varying 
+#' to make specific queries. For a data request the Quick Stats API returns
+#' JSON that when parsed to a data.frame contains 39 columns and a varying
 #' number of rows depending on the query. Unfortunately there is not a way to
 #' restrict the number of columns.
 #'
 #' @export
 #'
-#' @param ... either a named list of parameters or a series of parameters to 
+#' @param ... either a named list of parameters or a series of parameters to
 #'   form the query
 #' @param as whether to return a data.frame, list, or text string
 #'   [nassqs_GET()]
@@ -18,15 +18,15 @@
 #' @seealso [nassqs_GET()], [nassqs_yields()], [nassqs_acres()]
 #' @examples \donttest{
 #'   # Get corn yields in Virginia in 2012
-#'   params <- list(commodity_name = "CORN", 
-#'                  year = 2012, 
+#'   params <- list(commodity_name = "CORN",
+#'                  year = 2012,
 #'                  agg_level_desc = "COUNTY",
-#'                  state_alpha = "VA", 
+#'                  state_alpha = "VA",
 #'                  statisticcat_desc = "YIELD")
 #'   yields <- nassqs(params)
 #'   head(yields)
 #' }
-nassqs <- function(..., 
+nassqs <- function(...,
                    as = c("data.frame", "text", "list")) {
   as = match.arg(as)
   req <- nassqs_GET(..., api_path = "api_GET")
@@ -35,55 +35,55 @@ nassqs <- function(...,
 
 
 #' Issue a GET request to the NASS 'Quick Stats' API
-#' 
-#' This is the workhorse of the package that provides the core request 
-#' functionality to the NASS 'Quick Stats' API: 
+#'
+#' This is the workhorse of the package that provides the core request
+#' functionality to the NASS 'Quick Stats' API:
 #' [https://quickstats.nass.usda.gov/api](https://quickstats.nass.usda.gov/api).
-#' In most cases [nassqs()] or other high-level functions should be used. 
-#' `nassqs_GET` uses [httr::GET()] to make a HTTP GET request, which returns a 
+#' In most cases [nassqs()] or other high-level functions should be used.
+#' `nassqs_GET` uses [httr::GET()] to make a HTTP GET request, which returns a
 #' request object which must then be parsed to a data.frame, list, or other `R`
-#' object. Higher-level functions will do that parsing automatically. However, 
-#' if you need access to the request object directly, `nassqs_GET` provides 
+#' object. Higher-level functions will do that parsing automatically. However,
+#' if you need access to the request object directly, `nassqs_GET` provides
 #' that.
 #'
 #' @export
-#' 
-#' @param ... either a named list of parameters or a series of parameters to 
+#'
+#' @param ... either a named list of parameters or a series of parameters to
 #'   use in the query
 #' @param api_path the API path that determines the type of request being made
 #' @return a [httr::GET()] response object
 #' @examples \donttest{
 #'   # Yields for corn in 2012 in Washington
-#'   params <- list(commodity_name = "CORN", 
-#'                  year = 2012, 
+#'   params <- list(commodity_name = "CORN",
+#'                  year = 2012,
 #'                  agg_level_desc = "STATE",
 #'                  state_alpha = "WA",
 #'                  statisticcat_desc = "YIELD")
-#'   
+#'
 #'   # Returns a request object that must be parsed either manually or
 #'   # by using nassqs_parse()
 #'   response <- nassqs_GET(params)
 #'   yields <- nassqs_parse(response)
 #'   head(yields)
-#'   
+#'
 #'   # Get the number of records that would be returned for a given request
 #'   # Equivalent to 'nassqs_record_count(params)'
 #'   response <- nassqs_GET(params, api_path = "get_counts")
 #'   records <- nassqs_parse(response)
 #'   records
-#'   
+#'
 #'   # Get the list of allowable values for the parameters 'statisticcat_desc'
 #'   # Equivalent to 'nassqs_param_values("statisticcat_desc")'
-#'   req <- nassqs_GET(list(param = "statisticcat_desc"), 
+#'   req <- nassqs_GET(list(param = "statisticcat_desc"),
 #'                     api_path = "get_param_values")
 #'   statisticcat_desc_values <- nassqs_parse(req, as = "list")
 #'   head(statisticcat_desc_values)
 #' }
 nassqs_GET <- function(...,
-                       api_path = c("api_GET", 
-                                    "get_param_values", 
+                       api_path = c("api_GET",
+                                    "get_param_values",
                                     "get_counts")) {
- 
+
   # Check that the api key is set
   key <- Sys.getenv("NASSQS_TOKEN")
   if(identical(key, "")) {
@@ -93,24 +93,24 @@ nassqs_GET <- function(...,
 
   # match args
   api_path <- match.arg(api_path)
-  
+
   # get the full param list and make sure all arguments are in capital letters
   params <- expand_list(...)
-  
+
   if (api_path == "get_param_values") {
     # parameter names are lower case, so the query requires lower case terms
-    for(k in names(params)) { params[[k]] <- tolower(params[[k]]) }
+    params <- lapply(params, tolower)
   } else {
     # All other API calls require query terms in upper case
-    for(k in names(params)) { params[[k]] <- toupper(params[[k]]) }
-    
-    # except 'format', which must be lower case and one of 'json', 'csv', 
+    params <- lapply(params, toupper)
+
+    # except 'format', which must be lower case and one of 'json', 'csv',
     # or 'xml'
     if("format" %in% names(params)) {
       format <- tolower(params$format)
       params[["format"]] <- format
       if(!(format %in% c("json", "xml", "csv"))) {
-        stop(paste0("Your query parameters include 'format' as ", format, 
+        stop(paste0("Your query parameters include 'format' as ", format,
                     " but it should be one of 'json', 'xml', or 'csv'."))
       }
     }
@@ -119,25 +119,25 @@ nassqs_GET <- function(...,
   # Create the query
   query <- list(key = key)
   query <- append(query, params)
-  
+
   if(!("format" %in% names(query))) query['format'] <- "JSON"
-  
+
   # full url
   url <- paste0("https://quickstats.nass.usda.gov/api/", api_path)
   u <- httr::parse_url(url)
   u$query <- query
-  
+
   resp <- httr::GET(url, query = query, httr::progress())
   nassqs_check(resp)
-  
+
   resp
 }
 
 #' Check the response.
 #'
-#' Check that the response is valid, i.e. that it doesn't exceed 50,000 records 
+#' Check that the response is valid, i.e. that it doesn't exceed 50,000 records
 #' and that all the parameter values are valid. This is used to ensure that
-#' the query is valid before querying to reduce wait times before receiving an 
+#' the query is valid before querying to reduce wait times before receiving an
 #' error.
 #'
 #' @param response a [httr::GET()] request result returned from the API.
@@ -153,13 +153,13 @@ nassqs_check <- function(response) {
                 "your query."), call. = FALSE)
   }
   else {
-    stop("HTTP Failure: ", 
-         response$status_code, 
-         "\n", 
-         jsonlite::fromJSON(httr::content(response, 
-                                          as="text", 
-                                          type="text/json", 
-                                          encoding = "UTF-8")), 
+    stop("HTTP Failure: ",
+         response$status_code,
+         "\n",
+         jsonlite::fromJSON(httr::content(response,
+                                          as="text",
+                                          type="text/json",
+                                          encoding = "UTF-8")),
          call. = FALSE)
   }
 }
@@ -167,9 +167,9 @@ nassqs_check <- function(response) {
 #' Parse a response object from `nassqs_GET`.
 #'
 #' Returns a data frame, list, or text string. If a data.frame, all columns
-#' except `year` strings because the 'Quick Stats' data returns suppressed data 
-#' as '(D)', (Z)', or other character indicators which mean different things. 
-#' Converting the value to a numerical results in NA, which loses that 
+#' except `year` strings because the 'Quick Stats' data returns suppressed data
+#' as '(D)', (Z)', or other character indicators which mean different things.
+#' Converting the value to a numerical results in NA, which loses that
 #' information.
 #'
 #' @export
@@ -182,37 +182,37 @@ nassqs_check <- function(response) {
 #' @return a data frame, list, or text string of the content from the response.
 #' @examples \donttest{
 #'   # Set parameters and make the request
-#'   params <- list(commodity_name = "CORN", 
-#'                  year = 2012, 
+#'   params <- list(commodity_name = "CORN",
+#'                  year = 2012,
 #'                  agg_level_desc = "STATE",
 #'                  state_alpha = "WA",
 #'                  statisticcat_desc = "YIELD")
 #'   response <- nassqs_GET(params)
-#'   
+#'
 #'   # Parse the response to a data frame
 #'   corn <- nassqs_parse(response, as = "data.frame")
 #'   head(corn)
-#'   
+#'
 #'   # Parse the response into a raw character string.
 #'   corn_text<- nassqs_parse(response, as = "text")
 #'   head(corn_text)
 #'
 #'   # Get a list of parameter values and parse as a list
-#'   response <- nassqs_GET(list(param = "statisticcat_desc"), 
+#'   response <- nassqs_GET(list(param = "statisticcat_desc"),
 #'                     api_path = "get_param_values")
 #'   statisticcat_desc_values <- nassqs_parse(response, as = "list")
 #'   head(statisticcat_desc_values)
 #' }
 nassqs_parse <- function(req, as = c("data.frame", "list", "text"), ...) {
   as = match.arg(as)
-  
+
   # If an error or otherwise return an object that is not a response object,
   # return the object and exit
   if(!inherits(req, "response")) return(req)
 
   type <- req$headers[['content-type']]
   resp <- httr::content(req, as = "text", encoding = "UTF-8")
-  
+
   # process the data depending on returned data type
   if(as == "text") {
     ret <- resp
@@ -220,11 +220,11 @@ nassqs_parse <- function(req, as = c("data.frame", "list", "text"), ...) {
   else if(type %in% c("application/json", "application/json; charset=UTF-8")) { # format == JSON
     # Handle error where response is truncated if too long (only happens)
     # when making a call to the "get_param_values" api_path for 'domaincat_desc'
-    ret <- tryCatch(jsonlite::fromJSON(resp), 
-                    error = function(e) { 
+    ret <- tryCatch(jsonlite::fromJSON(resp),
+                    error = function(e) {
                       stop(paste0("JSON is malformed. This is a problem with ",
                                   "the Quick Stats API, not the rnassqs ",
-                                  "package. \n", 
+                                  "package. \n",
                                   e)) })
     if("data" %in% names(ret)) ret <- ret$data
 
@@ -244,7 +244,3 @@ nassqs_parse <- function(req, as = c("data.frame", "list", "text"), ...) {
   }
   ret
 }
-
-
-
-

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -7,3 +7,18 @@ skip_if_no_auth <- function() {
   }
 }
 
+with_mock_api <- function(expr) {
+  # Set a fake token just in this context
+  old_token <- Sys.getenv("NASSQS_TOKEN")
+  Sys.setenv(NASSQS_TOKEN = "API_KEY")
+  on.exit(Sys.setenv(NASSQS_TOKEN = old_token))
+
+  httptest::with_mock_api(expr)
+}
+
+with_authentication <- function(expr) {
+  if (!identical(Sys.getenv("NASSQS_TOKEN"), "")) {
+    # Only evaluate if a token is set
+    expr
+  }
+}

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,12 +1,5 @@
 library(httptest)
 
-# If no authentication, skip
-skip_if_no_auth <- function() {
-  if (Sys.getenv("NASSQS_TOKEN") %in% c("", "API_KEY")) {
-    skip("No authentication available")
-  }
-}
-
 with_mock_api <- function(expr) {
   # Set a fake token just in this context
   old_token <- Sys.getenv("NASSQS_TOKEN")

--- a/tests/testthat/quickstats.nass.usda.gov/api/api_GET-559ed7.R
+++ b/tests/testthat/quickstats.nass.usda.gov/api/api_GET-559ed7.R
@@ -1,0 +1,7 @@
+structure(
+  list(
+    url = "https://quickstats.nass.usda.gov/api/api_GET?key=API_KEY&commodity_desc=CORN&year=2012&agg_level_desc=STATE&statisticcat_desc=AREA%20HARVESTED&domaincat_desc=NOT%20SPECIFIED&state_alpha=VA&format=JSON",
+    status_code = 413
+  ),
+  class = "response"
+)

--- a/tests/testthat/quickstats.nass.usda.gov/api/api_GET-a17d57.R
+++ b/tests/testthat/quickstats.nass.usda.gov/api/api_GET-a17d57.R
@@ -1,0 +1,8 @@
+structure(
+  list(
+    url = "https://quickstats.nass.usda.gov/api/api_GET?key=API_KEY&commodity_desc=CORN&year=2102&agg_level_desc=STATE&statisticcat_desc=AREA%20HARVESTED&domaincat_desc=NOT%20SPECIFIED&state_alpha=VA&format=JSON",
+    status_code = 404,
+    content = charToRaw('{"message": "Not Found"}')
+  ),
+  class = "response"
+)

--- a/tests/testthat/test-params.R
+++ b/tests/testthat/test-params.R
@@ -10,7 +10,7 @@ nassqs_auth(key = "API_KEY")
 # Tests
 with_mock_api({
   test_that("nassqs_param_values forms a correct URL", {
-    expect_GET(nassqs_param_values("source_desc"), 
+    expect_GET(nassqs_param_values("source_desc"),
                "https://quickstats.nass.usda.gov/api/get_param_values?key=API_KEY&param=source_desc&format=JSON")
   })
 })
@@ -20,31 +20,29 @@ nassqs_auth(key = key)
 
 
 ### Tests with real API calls ----
-test_that("nassqs_param_values returns parameter values", {
-  skip_if_no_auth()
-  skip_on_cran()
-  
-  v = nassqs_param_values("source_desc")
-  expect_is(v, "character")
-  expect_is(v[[1]], "character")
-  expect_equal(nassqs_param_values("source_desc"), c("CENSUS", "SURVEY"))
+with_authentication({
+  test_that("nassqs_param_values returns parameter values", {
+    v = nassqs_param_values("source_desc")
+    expect_is(v, "character")
+    expect_is(v[[1]], "character")
+    expect_equal(nassqs_param_values("source_desc"), c("CENSUS", "SURVEY"))
+  })
 })
-
 
 ### Tests not involving the API ----
 test_that("nassqs_params() returns a list of parameters", {
-  expected_param_list <- c("agg_level_desc", "asd_code", "asd_desc", 
+  expected_param_list <- c("agg_level_desc", "asd_code", "asd_desc",
                            "begin_code", "class_desc", "commodity_desc",
-                           "congr_district_code", "country_code", 
+                           "congr_district_code", "country_code",
                            "country_name", "county_ansi",
                            "county_code", "county_name", "CV", "domaincat_desc",
                            "domain_desc", "end_code", "freq_desc", "group_desc",
-                           "load_time", "location_desc", "prodn_practice_desc", 
-                           "reference_period_desc", "region_desc", 
-                           "sector_desc", "short_desc", "state_alpha", 
-                           "state_ansi", "state_name", "state_fips_code", 
-                           "statisticcat_desc", "source_desc", "unit_desc", 
-                           "util_practice_desc", "Value", "watershed_code", 
+                           "load_time", "location_desc", "prodn_practice_desc",
+                           "reference_period_desc", "region_desc",
+                           "sector_desc", "short_desc", "state_alpha",
+                           "state_ansi", "state_name", "state_fips_code",
+                           "statisticcat_desc", "source_desc", "unit_desc",
+                           "util_practice_desc", "Value", "watershed_code",
                            "watershed_desc", "week_ending", "year", "zip_5")
   expect_equal(nassqs_params(), expected_param_list)
 })
@@ -52,7 +50,7 @@ test_that("nassqs_params() returns a list of parameters", {
 test_that("nassqs_params() accepts a single argument", {
   expected_output <- "source_desc: Data source. Either 'CENSUS' or 'SURVEY'"
   expect_equal(nassqs_params("source_desc"), expected_output)
-}) 
+})
 
 test_that("nassqs_params() accepts multiple arguments", {
   expected_output <- c(
@@ -67,4 +65,3 @@ test_that("nassqs_params() accepts a single simple list argument", {
     "county_name: County name")
   expect_equal(nassqs_params(c("source_desc", "county_name")), expected_output)
 })
-

--- a/tests/testthat/test-request.R
+++ b/tests/testthat/test-request.R
@@ -12,115 +12,88 @@ params = list(
 
 ### Test API URLs with mock APIs ----
 
-# First set the API KEY to a static value
-key <- Sys.getenv("NASSQS_TOKEN")
-nassqs_auth(key = "API_KEY")
-
-
 with_mock_api({
   test_that("nassqs forms a correct URL", {
     expected_url <- "https://quickstats.nass.usda.gov/api/api_GET?key=API_KEY&commodity_desc=CORN&year=2012&agg_level_desc=STATE&statisticcat_desc=AREA%20HARVESTED&domaincat_desc=NOT%20SPECIFIED&state_alpha=VA&format=JSON"
     expect_GET(nassqs(params), url = expected_url)
   })
-})
 
-with_mock_api({
   test_that("nassqs_GET() forms a correct URL", {
     expected_url <- "https://quickstats.nass.usda.gov/api/api_GET?key=API_KEY&commodity_desc=CORN&year=2012&agg_level_desc=STATE&statisticcat_desc=AREA%20HARVESTED&domaincat_desc=NOT%20SPECIFIED&state_alpha=VA&format=JSON"
     expect_GET(nassqs_GET(params), url = expected_url)
   })
 })
 
-# Set the key after finishing mock tests
-nassqs_auth(key = key)
-
 
 ### API tests that make real API calls if local and have an API key ----
-test_that("nassqs_GET successfully makes a request to the Quick Stats API", {
-  skip_if_no_auth()
-  skip_on_cran()
-  
-  req <- nassqs_GET(params)
-  expect_is(req, "response")
-})
+with_authentication({
+  test_that("nassqs_GET successfully makes a request to the Quick Stats API", {
+    req <- nassqs_GET(params)
+    expect_is(req, "response")
+  })
 
-test_that("nassqs_GET with api_path = 'api_GET' successfully makes a request to the Quick Stats API", {
-  skip_if_no_auth()
-  skip_on_cran()
-  
-  req <- nassqs_GET(params, api_path = 'api_GET')
-  expect_is(req, "response")
-})
+  test_that("nassqs_GET with api_path = 'api_GET' successfully makes a request to the Quick Stats API", {
+    req <- nassqs_GET(params, api_path = 'api_GET')
+    expect_is(req, "response")
+  })
 
-test_that("nassqs_GET with api_path = 'get_param_values' successfully makes a request to the Quick Stats API", {
-  skip_if_no_auth()
-  skip_on_cran()
-  
-  req <- nassqs_GET(param = "source_desc", api_path = "get_param_values")
-  expect_is(req, "response")
-  
-  values <- nassqs_parse(req)
-  expect_is(values, "list")
-})
+  test_that("nassqs_GET with api_path = 'get_param_values' successfully makes a request to the Quick Stats API", {
+    req <- nassqs_GET(param = "source_desc", api_path = "get_param_values")
+    expect_is(req, "response")
 
-test_that("nassqs_GET with api_path = 'get_counts' successfully makes a request to the Quick Stats API", {
-  skip_if_no_auth()
-  skip_on_cran()
-  
-  req <- nassqs_GET(params, api_path = "get_counts")
-  expect_is(req, "response")
-  
-  n <- nassqs_parse(req)
-  expect_is(n$count, "integer")
-})
+    values <- nassqs_parse(req)
+    expect_is(values, "list")
+  })
 
-test_that("nassqs_GET() works with lower case values", {
-  lower_params = list(
-    commodity_desc = "corn",
-    year = "2012",
-    agg_level_desc = "state",
-    statisticcat_desc = "area harvested",
-    domaincat_desc = "not specified",
-    state_alpha = "va"
-  )
-  
-  req <- nassqs_GET(lower_params)
-  d <- nassqs_parse(req)
-  expect_is(d, "data.frame")
-  expect_equal(ncol(d), 39)
-})
+  test_that("nassqs_GET with api_path = 'get_counts' successfully makes a request to the Quick Stats API", {
+    req <- nassqs_GET(params, api_path = "get_counts")
+    expect_is(req, "response")
 
-test_that("nassqs_parse successfully parses a request to the Quick Stats API", {
-  skip_if_no_auth()
-  skip_on_cran()
-  
-  req <- nassqs_GET(params)
-  d <- nassqs_parse(req)
-  expect_is(d, "data.frame")
-  expect_equal(ncol(d), 39)
-})
+    n <- nassqs_parse(req)
+    expect_is(n$count, "integer")
+  })
 
-test_that("nassqs_parse successfully parses CSV data", {
-  skip_if_no_auth()
-  skip_on_cran()
-  
-  csv_params <- params
-  csv_params[['format']] <- "csv"
-  req <- nassqs_GET(csv_params)
-  d <- nassqs_parse(req)
-  expect_is(d, "data.frame")
-  expect_equal(ncol(d), 39)
-})
+  test_that("nassqs_GET() works with lower case values", {
+    lower_params = list(
+      commodity_desc = "corn",
+      year = "2012",
+      agg_level_desc = "state",
+      statisticcat_desc = "area harvested",
+      domaincat_desc = "not specified",
+      state_alpha = "va"
+    )
 
+    req <- nassqs_GET(lower_params)
+    d <- nassqs_parse(req)
+    expect_is(d, "data.frame")
+    expect_equal(ncol(d), 39)
+  })
+
+  test_that("nassqs_parse successfully parses a request to the Quick Stats API", {
+    req <- nassqs_GET(params)
+    d <- nassqs_parse(req)
+    expect_is(d, "data.frame")
+    expect_equal(ncol(d), 39)
+  })
+
+  test_that("nassqs_parse successfully parses CSV data", {
+    csv_params <- params
+    csv_params[['format']] <- "csv"
+    req <- nassqs_GET(csv_params)
+    d <- nassqs_parse(req)
+    expect_is(d, "data.frame")
+    expect_equal(ncol(d), 39)
+  })
+})
 
 ### Non-API tests ---
 test_that("nassqs_GET returns error if no authentication provided in non-interactive session", {
   key <- Sys.getenv("NASSQS_TOKEN")
   Sys.unsetenv("NASSQS_TOKEN")
+  on.exit(Sys.setenv(NASSQS_TOKEN = key))
   expect_error(nassqs_GET(params),
                "Please use 'nassqs_auth(key = <your api key>)' to set your api key",
                fixed = TRUE)
-  Sys.setenv(NASSQS_TOKEN = key)
 })
 
 

--- a/tests/testthat/test-request.R
+++ b/tests/testthat/test-request.R
@@ -22,6 +22,15 @@ with_mock_api({
     expected_url <- "https://quickstats.nass.usda.gov/api/api_GET?key=API_KEY&commodity_desc=CORN&year=2012&agg_level_desc=STATE&statisticcat_desc=AREA%20HARVESTED&domaincat_desc=NOT%20SPECIFIED&state_alpha=VA&format=JSON"
     expect_GET(nassqs_GET(params), url = expected_url)
   })
+
+  test_that("Too-large request error is handled", {
+    p2 <- params
+    p2$year <- 2013
+    expect_error(
+      nassqs(p2),
+      "Request was too large. NASS requires that an API call returns a max"
+    )
+  })
 })
 
 

--- a/tests/testthat/test-request.R
+++ b/tests/testthat/test-request.R
@@ -44,6 +44,22 @@ with_mock_api({
       "Request was too large. NASS requires that an API call returns a max"
     )
   })
+
+  test_that("Other server error is handled", {
+    p3 <- params
+    p3$year <- 2102
+    expect_error(
+      nassqs(p3),
+      "HTTP Failure: 404"
+    )
+  })
+
+  test_that("Invalid format is handled", {
+    expect_error(
+      nassqs(format = "png"),
+      "Your query parameters include 'format' as png"
+    )
+  })
 })
 
 

--- a/tests/testthat/test-request.R
+++ b/tests/testthat/test-request.R
@@ -10,17 +10,30 @@ params = list(
   state_alpha = "VA"
 )
 
+lower_params = list(
+  commodity_desc = "corn",
+  year = "2012",
+  agg_level_desc = "state",
+  statisticcat_desc = "area harvested",
+  domaincat_desc = "not specified",
+  state_alpha = "va"
+)
+
 ### Test API URLs with mock APIs ----
 
 with_mock_api({
+  expected_url <- "https://quickstats.nass.usda.gov/api/api_GET?key=API_KEY&commodity_desc=CORN&year=2012&agg_level_desc=STATE&statisticcat_desc=AREA%20HARVESTED&domaincat_desc=NOT%20SPECIFIED&state_alpha=VA&format=JSON"
+
   test_that("nassqs forms a correct URL", {
-    expected_url <- "https://quickstats.nass.usda.gov/api/api_GET?key=API_KEY&commodity_desc=CORN&year=2012&agg_level_desc=STATE&statisticcat_desc=AREA%20HARVESTED&domaincat_desc=NOT%20SPECIFIED&state_alpha=VA&format=JSON"
     expect_GET(nassqs(params), url = expected_url)
   })
 
   test_that("nassqs_GET() forms a correct URL", {
-    expected_url <- "https://quickstats.nass.usda.gov/api/api_GET?key=API_KEY&commodity_desc=CORN&year=2012&agg_level_desc=STATE&statisticcat_desc=AREA%20HARVESTED&domaincat_desc=NOT%20SPECIFIED&state_alpha=VA&format=JSON"
     expect_GET(nassqs_GET(params), url = expected_url)
+  })
+
+  test_that("nassqs_GET() works with lower case values", {
+    expect_GET(nassqs(lower_params), url = expected_url)
   })
 
   test_that("Too-large request error is handled", {
@@ -60,22 +73,6 @@ with_authentication({
 
     n <- nassqs_parse(req)
     expect_is(n$count, "integer")
-  })
-
-  test_that("nassqs_GET() works with lower case values", {
-    lower_params = list(
-      commodity_desc = "corn",
-      year = "2012",
-      agg_level_desc = "state",
-      statisticcat_desc = "area harvested",
-      domaincat_desc = "not specified",
-      state_alpha = "va"
-    )
-
-    req <- nassqs_GET(lower_params)
-    d <- nassqs_parse(req)
-    expect_is(d, "data.frame")
-    expect_equal(ncol(d), 39)
   })
 
   test_that("nassqs_parse successfully parses a request to the Quick Stats API", {

--- a/tests/testthat/test-request.R
+++ b/tests/testthat/test-request.R
@@ -1,7 +1,7 @@
 context("test HTTP GET related functions")
 
 # Parameters
-params = list(
+params <- list(
   commodity_desc = "CORN",
   year = "2012",
   agg_level_desc = "STATE",
@@ -10,7 +10,7 @@ params = list(
   state_alpha = "VA"
 )
 
-lower_params = list(
+lower_params <- list(
   commodity_desc = "corn",
   year = "2012",
   agg_level_desc = "state",

--- a/tests/testthat/test-wrappers.R
+++ b/tests/testthat/test-wrappers.R
@@ -1,7 +1,7 @@
 context("tests wrappers and ease of use functions.")
 
 ### Setup
-params = list(
+params <- list(
   commodity_desc = "CORN",
   year = "2012",
   statisticcat_desc = "YIELD",
@@ -43,7 +43,7 @@ with_mock_api({
 ### API tests that require the API ----
 with_authentication({
   test_that("nassqs_record_count returns a numeric", {
-    v = nassqs_record_count(params)
+    v <- nassqs_record_count(params)
     expect_equal(is.numeric(v$count), TRUE)
   })
 })

--- a/tests/testthat/test-wrappers.R
+++ b/tests/testthat/test-wrappers.R
@@ -11,65 +11,39 @@ params = list(
 
 ### Test API URLs with mock APIs ----
 
-# First set the API KEY to a static value
-key <- Sys.getenv("NASSQS_TOKEN")
-nassqs_auth(key = "API_KEY")
-
-# Tests
 with_mock_api({
   test_that("nassqs_record_count forms a correct URL", {
     expect_GET(nassqs_record_count(params),
                  "https://quickstats.nass.usda.gov/api/get_counts?key=API_KEY&commodity_desc=CORN&year=2012&statisticcat_desc=YIELD&agg_level_desc=STATE&state_alpha=VA&state_alpha=WA&format=JSON")
   })
-})
 
-with_mock_api({
   test_that("nassqs_yield returns a correct URL", {
     expect_GET(nassqs_yields(params),
                "https://quickstats.nass.usda.gov/api/api_GET?key=API_KEY&commodity_desc=CORN&year=2012&statisticcat_desc=YIELD&agg_level_desc=STATE&state_alpha=VA&state_alpha=WA&format=JSON")
   })
-})
 
-with_mock_api({
   test_that("nassqs_yield returns a correct URL even if statisticcat_desc parameter is set to a different value", {
     params[['statisticcat_desc']] <- "AREA HARVESTED"
     expect_GET(nassqs_yields(params),
                "https://quickstats.nass.usda.gov/api/api_GET?key=API_KEY&commodity_desc=CORN&year=2012&statisticcat_desc=YIELD&agg_level_desc=STATE&state_alpha=VA&state_alpha=WA&format=JSON")
   })
-})
 
-with_mock_api({
   test_that("nassqs_area returns a correct URL", {
     expect_GET(nassqs_acres(params, area = "AREA BEARING"),
                "https://quickstats.nass.usda.gov/api/api_GET?key=API_KEY&commodity_desc=CORN&year=2012&statisticcat_desc=AREA%20BEARING&agg_level_desc=STATE&state_alpha=VA&state_alpha=WA&unit_desc=ACRES&format=JSON")
   })
-})
 
-with_mock_api({
   test_that("nassqs_area returns a correct URL when multiple areas are specified", {
     expect_GET(nassqs_acres(params, area = c("AREA HARVESTED", "AREA PLANTED")),
                  "https://quickstats.nass.usda.gov/api/api_GET?key=API_KEY&commodity_desc=CORN&year=2012&statisticcat_desc=AREA%20HARVESTED&statisticcat_desc=AREA%20PLANTED&agg_level_desc=STATE&state_alpha=VA&state_alpha=WA&unit_desc=ACRES&format=JSON")
   })
 })
 
-# Set the key after finishing mock tests
-nassqs_auth(key = key)
-
 
 ### API tests that require the API ----
-test_that("nassqs_record_count returns a numeric", {
-  skip_if_no_auth()
-  skip_on_cran()
-  
-  v = nassqs_record_count(params)
-  expect_equal(is.numeric(v$count), TRUE)
+with_authentication({
+  test_that("nassqs_record_count returns a numeric", {
+    v = nassqs_record_count(params)
+    expect_equal(is.numeric(v$count), TRUE)
+  })
 })
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
See https://github.com/ropensci/software-review/issues/298

I broke these out into separate commits so that you could see them in isolation. Each change is itself small, though the diffs look bigger because my text editor felt compelled to trim trailing whitespace (sorry about that).

These changes (1) get the test suite/`R CMD check` passing again where there is no auth token set (as it would be on CRAN) and (2) increase line coverage from 78% to 91%.