### PR TITLE
Documented arguments for parameters in nassqs()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Suggests:
   knitr,
   rmarkdown,
   testthat
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2
 Roxygen: list(markdown = TRUE)
 Encoding: UTF-8
 VignetteBuilder: knitr

--- a/R/params.R
+++ b/R/params.R
@@ -88,11 +88,11 @@ nassqs_params <- function(...) {
     zip_5 = "Zip code",
     format = "Format of the data request")
   
-  if(missing(...)) {
+  if (missing(...)) {
     return(names(param_list))
   } else {
     x <- list(...)
-    params <- if(length(nchar(x[[1]])) == 1) x else x[[1]]
+    params <- if (length(nchar(x[[1]])) == 1) x else x[[1]]
     p_desc <- sapply(params, function(p) { 
       paste0(p, ": ", param_list[[p]]) 
     }, USE.NAMES = FALSE)
@@ -126,13 +126,13 @@ nassqs_params <- function(...) {
 #'
 #'   # Valid values for a parameter given a specific set of additional
 #'   # parameters
-#'   nassqs_param_values("commodity_desc", county_code = "53077", year = 2017, group_desc = "EXPENSES")
+#'   nassqs_param_values("commodity_desc", state_fips_code = "53", county_code = "077", year = 2017, group_desc = "EXPENSES")
 #' }
 nassqs_param_values <- function(param, ...) {
   # Check if parameters are valid
   chk_param <- parameter_is_valid(param)
 
-  if(length(list(...)) == 0) {
+  if (length(list(...)) == 0) {
     params <- list(param = param) 
     res <- nassqs_parse(nassqs_GET(params, api_path = "get_param_values"), as = "list")[[1]]
   } else {

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -43,7 +43,7 @@ nassqs_record_count <- function(...) {
 #'     agg_level_desc = "STATE",
 #'     state_alpha = "WA")
 #'     
-#'   yields <- nassqs_yield(params)
+#'   yields <- nassqs_yields(params)
 #'   head(yields)
 #' }
 nassqs_yields <- function(...) {
@@ -68,7 +68,7 @@ nassqs_yields <- function(...) {
 #'     state_name = "WASHINGTON",
 #'     agg_level_desc = "STATE"
 #'   )
-#'   area <- nassqs_area(params, area = "AREA BEARING")
+#'   area <- nassqs_acres(params, area = "AREA BEARING")
 #'   head(area)
 #' }
 nassqs_acres <- function(...,

--- a/man/nassqs.Rd
+++ b/man/nassqs.Rd
@@ -4,7 +4,28 @@
 \alias{nassqs}
 \title{Get data and return a data frame}
 \usage{
-nassqs(..., as = c("data.frame", "text", "list"))
+nassqs(
+  ...,
+  as = c("data.frame", "text", "list"),
+  source_desc = NULL,
+  sector_desc = NULL,
+  group_desc = NULL,
+  commodity_desc = NULL,
+  short_desc = NULL,
+  domain_desc = NULL,
+  domaincat_desc = NULL,
+  agg_level_desc = NULL,
+  statisticcat_desc = NULL,
+  state_name = NULL,
+  asd_desc = NULL,
+  county_name = NULL,
+  region_desc = NULL,
+  zip_5 = NULL,
+  watershed_desc = NULL,
+  year = NULL,
+  freq_desc = NULL,
+  reference_period_desc = NULL
+)
 }
 \arguments{
 \item{...}{either a named list of parameters or a series of parameters to
@@ -12,6 +33,73 @@ form the query}
 
 \item{as}{whether to return a data.frame, list, or text string
 \code{\link[=nassqs_GET]{nassqs_GET()}}}
+
+\item{source_desc}{"Program" - Source of data ("CENSUS" or "SURVEY"). Census
+program includes the Census of Ag as well as follow up projects. Survey
+program includes national, state, and county surveys.}
+
+\item{sector_desc}{"Sector" - Five high level, broad categories useful to
+narrow down choices. ("ANIMALS & PRODUCTS", "CROPS", "DEMOGRAPHICS",
+"ECONOMICS", or "ENVIRONMENTAL")}
+
+\item{group_desc}{"Group" - Subsets within sector (e.g., under sector_desc =
+"CROPS", the groups are "FIELD CROPS", "FRUIT & TREE NUTS", "HORTICULTURE",
+and "VEGETABLES").}
+
+\item{commodity_desc}{"Commodity" - The primary subject of interest (e.g.,
+"CORN", "CATTLE", "LABOR", "TRACTORS", "OPERATORS").}
+
+\item{short_desc}{"Data Item" - A concatenation of six columns:
+commodity_desc, class_desc, prodn_practice_desc, util_practice_desc,
+statisticcat_desc, and unit_desc.}
+
+\item{domain_desc}{"Domain" - Generally another characteristic of operations
+that produce a particular commodity (e.g., "ECONOMIC CLASS", "AREA
+OPERATED", "NAICS CLASSIFICATION", "SALES"). For chemical usage data, the
+domain describes the type of chemical applied to the commodity. The
+domain_desc = "TOTAL" will have no further breakouts; i.e., the data value
+pertains completely to the short_desc.}
+
+\item{domaincat_desc}{"Domain Category" - Categories or partitions within a
+domain (e.g., under domain_desc = "SALES", domain categories include $1,000
+TO $9,999, $10,000 TO $19,999, etc).}
+
+\item{agg_level_desc}{"Geographic Level" - Aggregation level or geographic
+granularity of the data. ("AGRICULTURAL DISTRICT", "COUNTY",
+"INTERNATIONAL", "NATIONAL", "REGION : MULTI-STATE", "REGION : SUB-STATE",
+"STATE", "WATERSHED", or "ZIP CODE")}
+
+\item{statisticcat_desc}{"Category" - The aspect of a commodity being
+measured (e.g., "AREA HARVESTED", "PRICE RECEIVED", "INVENTORY", "SALES").}
+
+\item{state_name}{"State" - State full name.}
+
+\item{asd_desc}{"Ag District" - Ag statistics district name.}
+
+\item{county_name}{"County" - County name.}
+
+\item{region_desc}{"Region" - NASS defined geographic entities not readily
+defined by other standard geographic levels. A region can be a less than a
+state (SUB-STATE) or a group of states (MULTI-STATE), and may be specific
+to a commodity.}
+
+\item{zip_5}{"Zip Code" - US Postal Service 5-digit zip code.}
+
+\item{watershed_desc}{"Watershed" - Name assigned to the HUC.}
+
+\item{year}{"Year" - The numeric year of the data and can be either a
+character or numeric vector. Conditional values are also possible, for
+example a character vector of ">=1999" of "1999<=" will give years greater
+than or equal to 1999. Right now the logical values can either be
+greater/less than or equal to with the logical at either the beginning or
+end of a string with the year.}
+
+\item{freq_desc}{"Period Type" - Length of time covered ("ANNUAL", "SEASON",
+"MONTHLY", "WEEKLY", "POINT IN TIME"). "MONTHLY" often covers more than one
+month. "POINT IN TIME" is as of a particular day.}
+
+\item{reference_period_desc}{"Period" - The specific time frame, within a
+freq_desc.}
 }
 \value{
 a data frame, list, or text string of requested data.
@@ -28,7 +116,7 @@ restrict the number of columns.
 \examples{
 \donttest{
   # Get corn yields in Virginia in 2012
-  params <- list(commodity_name = "CORN",
+  params <- list(commodity_desc = "CORN",
                  year = 2012,
                  agg_level_desc = "COUNTY",
                  state_alpha = "VA",

--- a/man/nassqs_GET.Rd
+++ b/man/nassqs_GET.Rd
@@ -4,8 +4,7 @@
 \alias{nassqs_GET}
 \title{Issue a GET request to the NASS 'Quick Stats' API}
 \usage{
-nassqs_GET(..., api_path = c("api_GET", "get_param_values",
-  "get_counts"))
+nassqs_GET(..., api_path = c("api_GET", "get_param_values", "get_counts"))
 }
 \arguments{
 \item{...}{either a named list of parameters or a series of parameters to
@@ -30,7 +29,7 @@ that.
 \examples{
 \donttest{
   # Yields for corn in 2012 in Washington
-  params <- list(commodity_name = "CORN",
+  params <- list(commodity_desc = "CORN",
                  year = 2012,
                  agg_level_desc = "STATE",
                  state_alpha = "WA",

--- a/man/nassqs_acres.Rd
+++ b/man/nassqs_acres.Rd
@@ -4,10 +4,12 @@
 \alias{nassqs_acres}
 \title{Get NASS Area given a set of parameters.}
 \usage{
-nassqs_acres(..., area = c("AREA", "AREA PLANTED", "AREA BEARING",
-  "AREA BEARING & NON-BEARING", "AREA GROWN", "AREA HARVESTED",
-  "AREA IRRIGATED", "AREA NON-BEARING", "AREA PLANTED",
-  "AREA PLANTED, NET"))
+nassqs_acres(
+  ...,
+  area = c("AREA", "AREA PLANTED", "AREA BEARING", "AREA BEARING & NON-BEARING",
+    "AREA GROWN", "AREA HARVESTED", "AREA IRRIGATED", "AREA NON-BEARING", "AREA PLANTED",
+    "AREA PLANTED, NET")
+)
 }
 \arguments{
 \item{...}{either a named list of parameters or a series of parameters to
@@ -30,7 +32,7 @@ Get NASS Area given a set of parameters.
     state_name = "WASHINGTON",
     agg_level_desc = "STATE"
   )
-  area <- nassqs_area(params, area = "AREA BEARING")
+  area <- nassqs_acres(params, area = "AREA BEARING")
   head(area)
 }
 }

--- a/man/nassqs_auth.Rd
+++ b/man/nassqs_auth.Rd
@@ -16,7 +16,7 @@ your API key in four ways:
 \details{
 \enumerate{
 \item directly or as a variable from your \code{R}
-program: \code{nassqs_auth(key = "<your api key>"}
+program: \verb{nassqs_auth(key = "<your api key>"}
 \item by setting \code{NASSQS_TOKEN} in your \code{R} environment file (you'll never have
 to enter it again).
 \item by entering it into the console when asked (it will be stored for the

--- a/man/nassqs_param_values.Rd
+++ b/man/nassqs_param_values.Rd
@@ -34,6 +34,6 @@ including additional parameters
 
   # Valid values for a parameter given a specific set of additional
   # parameters
-  nassqs_param_values("commodity_desc", county_code = "53077", year = 2017, group_desc = "EXPENSES")
+  nassqs_param_values("commodity_desc", state_fips_code = "53", county_code = "077", year = 2017, group_desc = "EXPENSES")
 }
 }

--- a/man/nassqs_parse.Rd
+++ b/man/nassqs_parse.Rd
@@ -27,7 +27,7 @@ information.
 \examples{
 \donttest{
   # Set parameters and make the request
-  params <- list(commodity_name = "CORN",
+  params <- list(commodity_desc = "CORN",
                  year = 2012,
                  agg_level_desc = "STATE",
                  state_alpha = "WA",

--- a/man/nassqs_yields.Rd
+++ b/man/nassqs_yields.Rd
@@ -26,7 +26,7 @@ simplify common requests.
     agg_level_desc = "STATE",
     state_alpha = "WA")
     
-  yields <- nassqs_yield(params)
+  yields <- nassqs_yields(params)
   head(yields)
 }
 }


### PR DESCRIPTION
Borrowing from [usdarnass](https://github.com/rdinter/usdarnass), the major parameters for the [Quick Stats](https://quickstats.nass.usda.gov/) were integrated to the `nassqs()` function. The advantage is that the arguments are hard coded which can alleviate any potential typos in a Quick Stats parameter. Ironically, there were a few typos in the examples of various functions for rnassqs where `commodity_desc` was actually referenced as `commodity_name` and created errors in documentation. These typos have also been corrected.